### PR TITLE
[Fix rwkv6] Fix out-of-bound access by boundary checking

### DIFF
--- a/fla/ops/rwkv6/chunk.py
+++ b/fla/ops/rwkv6/chunk.py
@@ -50,7 +50,7 @@ def chunk_rwkv6_fwd_cumsum_kernel(
     # [BT, BS]
     b_s = tl.load(p_s, boundary_check=(0, 1)).to(tl.float32)
     b_o = tl.dot(m_s, b_s, allow_tf32=False)
-    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(1, 1))
     tl.store(p_o_minus_s, (b_o - b_s).to(p_o_minus_s.dtype.element_ty), boundary_check=(0, 1))
 
 


### PR DESCRIPTION
Use `boundary_check` on the first dimension to avoid possible out-of-bound access.